### PR TITLE
Unify conventions and add GitHub governance

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owner for all files
+* @oborchers

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,48 @@
+name: Bug Report
+description: Report something that isn't working correctly
+labels: ["bug"]
+body:
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug.
+      placeholder: Describe the bug...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+      description: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction steps
+      description: Minimal code to reproduce the issue.
+      render: python
+    validations:
+      required: true
+  - type: input
+    id: python-version
+    attributes:
+      label: Python version
+      placeholder: "3.12"
+    validations:
+      required: true
+  - type: input
+    id: pydantic-version
+    attributes:
+      label: Pydantic version
+      placeholder: "2.10.0"
+    validations:
+      required: true
+  - type: input
+    id: pydantypes-version
+    attributes:
+      label: pydantypes version
+      placeholder: "0.1.0"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,43 @@
+name: Feature Request
+description: Suggest a new validated type or enhancement
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use case
+      description: What problem does this solve? When would you use this type?
+    validations:
+      required: true
+  - type: textarea
+    id: proposed-type
+    attributes:
+      label: Proposed type
+      description: Describe the type, its constraints, and valid/invalid examples.
+      render: python
+    validations:
+      required: true
+  - type: input
+    id: source-url
+    attributes:
+      label: Source URL
+      description: Link to the official spec or docs for the format being validated.
+      placeholder: "https://docs.example.com/format-spec"
+    validations:
+      required: true
+  - type: dropdown
+    id: module
+    attributes:
+      label: Module
+      description: Which module should this type belong to?
+      options:
+        - cloud/aws
+        - cloud/azure
+        - cloud/gcp
+        - devops
+        - web
+        - data
+        - ai
+        - other / unsure
+    validations:
+      required: true

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,13 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    labels:
+      - "dependencies"
+      - "github-actions"
   - package-ecosystem: "uv"
     directory: "/"
     schedule:
       interval: "weekly"
+    labels:
+      - "dependencies"
+      - "python"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,9 @@
+## Summary
+
+<!-- What does this PR do? Why is it needed? -->
+
+## Checklist
+
+- [ ] `make check` passes (lint + typecheck + tests)
+- [ ] Tests added or updated for new/changed behaviour
+- [ ] Docs updated if needed

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,24 @@
+name: Dependabot Auto-Merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Auto-merge patch and minor updates
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -165,7 +165,7 @@ The placement depends on the pattern:
 | **A** (str subclass) | `ClassVar` on the class | `_pattern: ClassVar[re.Pattern[str]] = re.compile(...)` |
 | **B** (Annotated) | Module level | `_EC2_INSTANCE_ID_RE = re.compile(...)` |
 
-Module-level regexes use the naming convention `_UPPER_SNAKE_CASE_RE`.
+Module-level regexes use the naming convention `_UPPER_SNAKE_CASE_RE`. The `_RE` suffix is mandatory — `_PATTERN` is prohibited.
 
 ### Why Python `re` Instead of Pydantic's Rust Regex
 
@@ -203,12 +203,16 @@ Rules:
 
 ## Docstrings
 
-Every module, class, and function has a docstring.
+Every module, class, and function has a docstring. No exceptions.
 
 - **Module:** `"""AWS storage types."""` — short, descriptive
 - **Pattern A class:** `"""An S3 URI like s3://bucket/key with parsed properties."""` — one-liner
-- **Pattern A methods:** `"""Create and validate a new S3Uri instance."""` — one-line, imperative
-- **Pattern B validator:** `"""Validate an EC2 instance ID format."""` — one-line, imperative
+- **Pattern A methods:** Every `__new__`, `_validate`, `__get_pydantic_core_schema__`, and `__get_pydantic_json_schema__` must have a one-line docstring. Templates:
+  - `__new__`: `"""Create and validate a new {ClassName} instance."""`
+  - `_validate`: `"""Validate a string as a {description}."""`
+  - `__get_pydantic_core_schema__`: `"""Return the Pydantic core schema for {ClassName}."""`
+  - `__get_pydantic_json_schema__`: `"""Return the JSON schema for {ClassName}."""`
+- **Pattern B validator:** Every `_validate_*` function must have a one-line docstring: `"""Validate a {type description} format."""`
 - **Pattern C class:** `"""AWS region identifiers."""` — one-liner
 - **`__init__.py`:** `"""AWS cloud resource types."""` — descriptive module docstring
 - **Test module:** `"""Tests for AWS storage types."""`
@@ -317,6 +321,8 @@ All Pattern A types delegate to this in `__get_pydantic_core_schema__`.
 Mirror source: `src/pydantypes/cloud/aws/storage.py` → `tests/cloud/aws/test_storage.py`
 
 One test file per source file. Module docstring: `"""Tests for AWS storage types."""`
+
+All tests use flat parametrized functions — class-based test grouping (`TestFooValid`, `TestFooInvalid`) is prohibited.
 
 ### Test Model
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ pip install pydantypes
 
 ### Always Analyze Codebase Before Making Changes
 
-Check existing patterns first, never invent new ones. See [ARCHITECTURE.md](ARCHITECTURE.md) for the canonical reference on type patterns (A/B/C/D), regex placement, docstring conventions, error handling, JSON schema, and test structure.
+Check existing patterns first, never invent new ones. The `cloud/` modules are the exemplar — all other modules (devops/, web/, data/, ai/) must follow the same conventions. See [ARCHITECTURE.md](ARCHITECTURE.md) for the canonical reference on type patterns (A/B/C/D), regex placement, docstring conventions, error handling, JSON schema, and test structure.
 
 ```bash
 tree src/pydantypes/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,11 +76,15 @@ all = [
 [tool.ruff]
 line-length = 100
 target-version = "py310"
+src = ["src"]
 extend-exclude = ["_version.py"]
 
 [tool.ruff.lint]
 select = ["E", "F", "UP", "B", "SIM", "I", "PLC", "RUF", "PT", "N"]
-ignore = []
+ignore = ["E501"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["pydantypes"]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**" = ["PLC0415"]

--- a/src/pydantypes/cloud/azure/compute.py
+++ b/src/pydantypes/cloud/azure/compute.py
@@ -8,7 +8,7 @@ from typing import Annotated
 from pydantic import AfterValidator, WithJsonSchema
 from pydantic_core import PydanticCustomError
 
-_FUNCTION_APP_NAME_PATTERN = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9-]{0,58}[a-zA-Z0-9]$")
+_FUNCTION_APP_NAME_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9-]{0,58}[a-zA-Z0-9]$")
 _APP_SERVICE_NAME_RE = re.compile(r"^[a-zA-Z0-9]([a-zA-Z0-9-]{0,57}[a-zA-Z0-9])?$")
 _AKS_CLUSTER_NAME_RE = re.compile(r"^[a-zA-Z0-9]([a-zA-Z0-9_-]{0,61}[a-zA-Z0-9])?$")
 _CONTAINER_APP_NAME_RE = re.compile(r"^[a-z]([a-z0-9-]{0,29}[a-z0-9])?$")
@@ -18,7 +18,7 @@ _API_MANAGEMENT_NAME_RE = re.compile(r"^[a-zA-Z]([a-zA-Z0-9-]{0,48}[a-zA-Z0-9])?
 
 def _validate_function_app_name(v: str) -> str:
     """Validate an Azure Function App name format."""
-    if not _FUNCTION_APP_NAME_PATTERN.match(v):
+    if not _FUNCTION_APP_NAME_RE.match(v):
         raise PydanticCustomError(
             "azure_function_app_name",
             "Invalid Azure Function App name: {value}",

--- a/src/pydantypes/cloud/azure/database.py
+++ b/src/pydantypes/cloud/azure/database.py
@@ -8,8 +8,8 @@ from typing import Annotated
 from pydantic import AfterValidator, WithJsonSchema
 from pydantic_core import PydanticCustomError
 
-_COSMOS_DB_ACCOUNT_NAME_PATTERN = re.compile(r"^[a-z0-9][a-z0-9-]{1,42}[a-z0-9]$")
-_SQL_SERVER_NAME_PATTERN = re.compile(r"^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$")
+_COSMOS_DB_ACCOUNT_NAME_RE = re.compile(r"^[a-z0-9][a-z0-9-]{1,42}[a-z0-9]$")
+_SQL_SERVER_NAME_RE = re.compile(r"^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$")
 _REDIS_CACHE_NAME_RE = re.compile(r"^[a-zA-Z0-9](?!.*--)[a-zA-Z0-9-]{0,61}[a-zA-Z0-9]$")
 _DATA_FACTORY_NAME_RE = re.compile(r"^[a-zA-Z0-9](?!.*--)[a-zA-Z0-9-]{1,61}[a-zA-Z0-9]$")
 _DATABRICKS_WORKSPACE_NAME_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_-]{1,62}[a-zA-Z0-9]$")
@@ -17,7 +17,7 @@ _DATABRICKS_WORKSPACE_NAME_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_-]{1,62}[a-z
 
 def _validate_cosmos_db_account_name(v: str) -> str:
     """Validate an Azure Cosmos DB account name format."""
-    if not _COSMOS_DB_ACCOUNT_NAME_PATTERN.match(v):
+    if not _COSMOS_DB_ACCOUNT_NAME_RE.match(v):
         raise PydanticCustomError(
             "azure_cosmos_db_account_name",
             "Invalid Azure Cosmos DB account name: {value}",
@@ -28,7 +28,7 @@ def _validate_cosmos_db_account_name(v: str) -> str:
 
 def _validate_sql_server_name(v: str) -> str:
     """Validate an Azure SQL Server name format."""
-    if not _SQL_SERVER_NAME_PATTERN.match(v):
+    if not _SQL_SERVER_NAME_RE.match(v):
         raise PydanticCustomError(
             "azure_sql_server_name",
             "Invalid Azure SQL Server name: {value}",

--- a/src/pydantypes/cloud/azure/identity.py
+++ b/src/pydantypes/cloud/azure/identity.py
@@ -8,17 +8,17 @@ from typing import Annotated
 from pydantic import AfterValidator, WithJsonSchema
 from pydantic_core import PydanticCustomError
 
-_UUID_PATTERN = re.compile(
+_UUID_RE = re.compile(
     r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
     re.IGNORECASE,
 )
 
-_RESOURCE_GROUP_PATTERN = re.compile(r"^[a-zA-Z0-9_\-.()]{1,90}$")
+_RESOURCE_GROUP_RE = re.compile(r"^[a-zA-Z0-9_\-.()]{1,90}$")
 
 
 def _validate_subscription_id(v: str) -> str:
     """Validate an Azure subscription ID format."""
-    if not _UUID_PATTERN.match(v):
+    if not _UUID_RE.match(v):
         raise PydanticCustomError(
             "azure_subscription_id",
             "Invalid Azure Subscription ID: {value}",
@@ -45,7 +45,7 @@ SubscriptionId = Annotated[
 
 def _validate_tenant_id(v: str) -> str:
     """Validate an Azure tenant ID format."""
-    if not _UUID_PATTERN.match(v):
+    if not _UUID_RE.match(v):
         raise PydanticCustomError(
             "azure_tenant_id",
             "Invalid Azure Tenant ID: {value}",
@@ -72,7 +72,7 @@ TenantId = Annotated[
 
 def _validate_resource_group_name(v: str) -> str:
     """Validate an Azure resource group name format."""
-    if not _RESOURCE_GROUP_PATTERN.match(v) or v.endswith("."):
+    if not _RESOURCE_GROUP_RE.match(v) or v.endswith("."):
         raise PydanticCustomError(
             "azure_resource_group_name",
             "Invalid Azure Resource Group name: {value}",

--- a/src/pydantypes/cloud/azure/messaging.py
+++ b/src/pydantypes/cloud/azure/messaging.py
@@ -8,13 +8,13 @@ from typing import Annotated
 from pydantic import AfterValidator, WithJsonSchema
 from pydantic_core import PydanticCustomError
 
-_SERVICE_BUS_NAMESPACE_PATTERN = re.compile(r"^[a-zA-Z][a-zA-Z0-9-]{4,48}[a-zA-Z0-9]$")
+_SERVICE_BUS_NAMESPACE_RE = re.compile(r"^[a-zA-Z][a-zA-Z0-9-]{4,48}[a-zA-Z0-9]$")
 _EVENT_HUB_NAMESPACE_NAME_RE = re.compile(r"^[a-zA-Z][a-zA-Z0-9-]{4,48}[a-zA-Z0-9]$")
 
 
 def _validate_service_bus_namespace(v: str) -> str:
     """Validate an Azure Service Bus namespace format."""
-    if not _SERVICE_BUS_NAMESPACE_PATTERN.match(v):
+    if not _SERVICE_BUS_NAMESPACE_RE.match(v):
         raise PydanticCustomError(
             "azure_service_bus_namespace",
             "Invalid Azure Service Bus namespace: {value}",

--- a/src/pydantypes/data/sql.py
+++ b/src/pydantypes/data/sql.py
@@ -25,6 +25,7 @@ class TableIdentifier(str):
     table_name: str
 
     def __new__(cls, value: str) -> TableIdentifier:
+        """Create and validate a new TableIdentifier instance."""
         m = cls._pattern.match(value)
         if not m:
             raise PydanticCustomError(
@@ -42,18 +43,21 @@ class TableIdentifier(str):
 
     @classmethod
     def _validate(cls, value: str) -> TableIdentifier:
+        """Validate a string as a SQL table identifier."""
         return cls(value)
 
     @classmethod
     def __get_pydantic_core_schema__(
         cls, source_type: Any, handler: GetCoreSchemaHandler
     ) -> CoreSchema:
+        """Return the Pydantic core schema for TableIdentifier."""
         return _str_type_core_schema(cls, source_type, handler)
 
     @classmethod
     def __get_pydantic_json_schema__(
         cls, _core_schema: CoreSchema, handler: GetJsonSchemaHandler
     ) -> JsonSchemaValue:
+        """Return the JSON schema for TableIdentifier."""
         return {
             "type": "string",
             "format": "sql-table-identifier",

--- a/src/pydantypes/devops/docker.py
+++ b/src/pydantypes/devops/docker.py
@@ -34,6 +34,7 @@ class DockerImageRef(str):
     digest: str | None
 
     def __new__(cls, value: str) -> DockerImageRef:
+        """Create and validate a new DockerImageRef instance."""
         m = cls._pattern.match(value)
         if not m:
             raise PydanticCustomError(
@@ -50,18 +51,21 @@ class DockerImageRef(str):
 
     @classmethod
     def _validate(cls, value: str) -> DockerImageRef:
+        """Validate a string as a Docker image reference."""
         return cls(value)
 
     @classmethod
     def __get_pydantic_core_schema__(
         cls, source_type: Any, handler: GetCoreSchemaHandler
     ) -> CoreSchema:
+        """Return the Pydantic core schema for DockerImageRef."""
         return _str_type_core_schema(cls, source_type, handler)
 
     @classmethod
     def __get_pydantic_json_schema__(
         cls, _core_schema: CoreSchema, handler: GetJsonSchemaHandler
     ) -> JsonSchemaValue:
+        """Return the JSON schema for DockerImageRef."""
         return {
             "type": "string",
             "format": "docker-image-ref",

--- a/src/pydantypes/devops/helm.py
+++ b/src/pydantypes/devops/helm.py
@@ -8,11 +8,12 @@ from typing import Annotated
 from pydantic import AfterValidator, WithJsonSchema
 from pydantic_core import PydanticCustomError
 
-_HELM_CHART_NAME_PATTERN = re.compile(r"^[a-z0-9][-a-z0-9]*$")
+_HELM_CHART_NAME_RE = re.compile(r"^[a-z0-9][-a-z0-9]*$")
 
 
 def _validate_helm_chart_name(v: str) -> str:
-    if not _HELM_CHART_NAME_PATTERN.match(v):
+    """Validate a Helm chart name format."""
+    if not _HELM_CHART_NAME_RE.match(v):
         raise PydanticCustomError(
             "helm_chart_name",
             "Invalid Helm chart name: {value}",
@@ -28,7 +29,7 @@ HelmChartName = Annotated[
     WithJsonSchema(
         {
             "type": "string",
-            "pattern": _HELM_CHART_NAME_PATTERN.pattern,
+            "pattern": _HELM_CHART_NAME_RE.pattern,
             "description": "A valid Helm chart name.",
             "examples": ["nginx", "cert-manager"],
             "title": "HelmChartName",

--- a/src/pydantypes/devops/k8s.py
+++ b/src/pydantypes/devops/k8s.py
@@ -11,13 +11,14 @@ from pydantic_core import CoreSchema, PydanticCustomError
 
 from pydantypes._internal import _str_type_core_schema
 
-_K8S_NAMESPACE_PATTERN = re.compile(r"^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$")
-_K8S_RESOURCE_PATTERN = re.compile(r"^[a-z0-9]([a-z0-9.-]{0,251}[a-z0-9])?$")
-_K8S_LABEL_VALUE_PATTERN = re.compile(r"^[a-zA-Z0-9]([a-zA-Z0-9._-]{0,61}[a-zA-Z0-9])?$")
+_K8S_NAMESPACE_RE = re.compile(r"^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$")
+_K8S_RESOURCE_RE = re.compile(r"^[a-z0-9]([a-z0-9.-]{0,251}[a-z0-9])?$")
+_K8S_LABEL_VALUE_RE = re.compile(r"^[a-zA-Z0-9]([a-zA-Z0-9._-]{0,61}[a-zA-Z0-9])?$")
 
 
 def _validate_k8s_namespace_name(v: str) -> str:
-    if not _K8S_NAMESPACE_PATTERN.match(v):
+    """Validate a Kubernetes namespace name format."""
+    if not _K8S_NAMESPACE_RE.match(v):
         raise PydanticCustomError(
             "k8s_namespace_name",
             "Invalid Kubernetes namespace name: {value}",
@@ -33,7 +34,7 @@ K8sNamespaceName = Annotated[
     WithJsonSchema(
         {
             "type": "string",
-            "pattern": _K8S_NAMESPACE_PATTERN.pattern,
+            "pattern": _K8S_NAMESPACE_RE.pattern,
             "description": "A valid Kubernetes namespace name (RFC 1123 DNS label).",
             "examples": ["default", "kube-system"],
             "title": "K8sNamespaceName",
@@ -43,7 +44,8 @@ K8sNamespaceName = Annotated[
 
 
 def _validate_k8s_resource_name(v: str) -> str:
-    if not _K8S_RESOURCE_PATTERN.match(v):
+    """Validate a Kubernetes resource name format."""
+    if not _K8S_RESOURCE_RE.match(v):
         raise PydanticCustomError(
             "k8s_resource_name",
             "Invalid Kubernetes resource name: {value}",
@@ -65,7 +67,7 @@ K8sResourceName = Annotated[
     WithJsonSchema(
         {
             "type": "string",
-            "pattern": _K8S_RESOURCE_PATTERN.pattern,
+            "pattern": _K8S_RESOURCE_RE.pattern,
             "description": (
                 "A valid Kubernetes resource name (RFC 1123 DNS subdomain, max 253 chars)."
             ),
@@ -89,6 +91,7 @@ class K8sLabelKey(str):
     name: str
 
     def __new__(cls, value: str) -> K8sLabelKey:
+        """Create and validate a new K8sLabelKey instance."""
         m = cls._pattern.match(value)
         if not m:
             raise PydanticCustomError(
@@ -103,18 +106,21 @@ class K8sLabelKey(str):
 
     @classmethod
     def _validate(cls, value: str) -> K8sLabelKey:
+        """Validate a string as a Kubernetes label key."""
         return cls(value)
 
     @classmethod
     def __get_pydantic_core_schema__(
         cls, source_type: Any, handler: GetCoreSchemaHandler
     ) -> CoreSchema:
+        """Return the Pydantic core schema for K8sLabelKey."""
         return _str_type_core_schema(cls, source_type, handler)
 
     @classmethod
     def __get_pydantic_json_schema__(
         cls, _core_schema: CoreSchema, handler: GetJsonSchemaHandler
     ) -> JsonSchemaValue:
+        """Return the JSON schema for K8sLabelKey."""
         return {
             "type": "string",
             "format": "k8s-label-key",
@@ -126,9 +132,10 @@ class K8sLabelKey(str):
 
 
 def _validate_k8s_label_value(v: str) -> str:
+    """Validate a Kubernetes label value format."""
     if v == "":
         return v
-    if not _K8S_LABEL_VALUE_PATTERN.match(v):
+    if not _K8S_LABEL_VALUE_RE.match(v):
         raise PydanticCustomError(
             "k8s_label_value",
             "Invalid Kubernetes label value: {value}",
@@ -144,7 +151,7 @@ K8sLabelValue = Annotated[
     WithJsonSchema(
         {
             "type": "string",
-            "pattern": _K8S_LABEL_VALUE_PATTERN.pattern,
+            "pattern": _K8S_LABEL_VALUE_RE.pattern,
             "description": "A valid Kubernetes label value (max 63 chars, empty allowed).",
             "examples": ["v1.0", "production", ""],
             "title": "K8sLabelValue",

--- a/src/pydantypes/devops/terraform.py
+++ b/src/pydantypes/devops/terraform.py
@@ -24,6 +24,7 @@ class TerraformResourceAddress(str):
     resource_name: str
 
     def __new__(cls, value: str) -> TerraformResourceAddress:
+        """Create and validate a new TerraformResourceAddress instance."""
         m = cls._pattern.match(value)
         if not m:
             raise PydanticCustomError(
@@ -38,18 +39,21 @@ class TerraformResourceAddress(str):
 
     @classmethod
     def _validate(cls, value: str) -> TerraformResourceAddress:
+        """Validate a string as a Terraform resource address."""
         return cls(value)
 
     @classmethod
     def __get_pydantic_core_schema__(
         cls, source_type: Any, handler: GetCoreSchemaHandler
     ) -> CoreSchema:
+        """Return the Pydantic core schema for TerraformResourceAddress."""
         return _str_type_core_schema(cls, source_type, handler)
 
     @classmethod
     def __get_pydantic_json_schema__(
         cls, _core_schema: CoreSchema, handler: GetJsonSchemaHandler
     ) -> JsonSchemaValue:
+        """Return the JSON schema for TerraformResourceAddress."""
         return {
             "type": "string",
             "format": "terraform-resource-address",

--- a/src/pydantypes/web/hash.py
+++ b/src/pydantypes/web/hash.py
@@ -8,13 +8,14 @@ from typing import Annotated
 from pydantic import AfterValidator, WithJsonSchema
 from pydantic_core import PydanticCustomError
 
-_SHA256_PATTERN = re.compile(r"^[0-9a-fA-F]{64}$")
-_SHA1_PATTERN = re.compile(r"^[0-9a-fA-F]{40}$")
-_MD5_PATTERN = re.compile(r"^[0-9a-fA-F]{32}$")
+_SHA256_RE = re.compile(r"^[0-9a-fA-F]{64}$")
+_SHA1_RE = re.compile(r"^[0-9a-fA-F]{40}$")
+_MD5_RE = re.compile(r"^[0-9a-fA-F]{32}$")
 
 
 def _validate_sha256_hex(v: str) -> str:
-    if not _SHA256_PATTERN.match(v):
+    """Validate a SHA-256 hex digest format."""
+    if not _SHA256_RE.match(v):
         raise PydanticCustomError(
             "sha256_hex",
             "Invalid SHA-256 hex digest: expected 64 hex characters. Got: {value}",
@@ -24,7 +25,8 @@ def _validate_sha256_hex(v: str) -> str:
 
 
 def _validate_sha1_hex(v: str) -> str:
-    if not _SHA1_PATTERN.match(v):
+    """Validate a SHA-1 hex digest format."""
+    if not _SHA1_RE.match(v):
         raise PydanticCustomError(
             "sha1_hex",
             "Invalid SHA-1 hex digest: expected 40 hex characters. Got: {value}",
@@ -34,7 +36,8 @@ def _validate_sha1_hex(v: str) -> str:
 
 
 def _validate_md5_hex(v: str) -> str:
-    if not _MD5_PATTERN.match(v):
+    """Validate an MD5 hex digest format."""
+    if not _MD5_RE.match(v):
         raise PydanticCustomError(
             "md5_hex",
             "Invalid MD5 hex digest: expected 32 hex characters. Got: {value}",

--- a/src/pydantypes/web/jwt.py
+++ b/src/pydantypes/web/jwt.py
@@ -21,6 +21,7 @@ class Jwt(str):
     payload: dict[str, Any]
 
     def __new__(cls, value: str) -> Jwt:
+        """Create and validate a new Jwt instance."""
         parts = value.split(".")
         if len(parts) != 3:
             raise PydanticCustomError(
@@ -58,18 +59,21 @@ class Jwt(str):
 
     @classmethod
     def _validate(cls, value: str) -> Jwt:
+        """Validate a string as a JSON Web Token."""
         return cls(value)
 
     @classmethod
     def __get_pydantic_core_schema__(
         cls, source_type: Any, handler: GetCoreSchemaHandler
     ) -> CoreSchema:
+        """Return the Pydantic core schema for Jwt."""
         return _str_type_core_schema(cls, source_type, handler)
 
     @classmethod
     def __get_pydantic_json_schema__(
         cls, _core_schema: CoreSchema, handler: GetJsonSchemaHandler
     ) -> JsonSchemaValue:
+        """Return the JSON schema for Jwt."""
         return {
             "type": "string",
             "format": "jwt",

--- a/src/pydantypes/web/mime.py
+++ b/src/pydantypes/web/mime.py
@@ -27,6 +27,7 @@ class MimeType(str):
     parameters: dict[str, str]
 
     def __new__(cls, value: str) -> MimeType:
+        """Create and validate a new MimeType instance."""
         m = cls._pattern.match(value)
         if not m:
             raise PydanticCustomError(
@@ -52,18 +53,21 @@ class MimeType(str):
 
     @classmethod
     def _validate(cls, value: str) -> MimeType:
+        """Validate a string as a MIME type."""
         return cls(value)
 
     @classmethod
     def __get_pydantic_core_schema__(
         cls, source_type: Any, handler: GetCoreSchemaHandler
     ) -> CoreSchema:
+        """Return the Pydantic core schema for MimeType."""
         return _str_type_core_schema(cls, source_type, handler)
 
     @classmethod
     def __get_pydantic_json_schema__(
         cls, _core_schema: CoreSchema, handler: GetJsonSchemaHandler
     ) -> JsonSchemaValue:
+        """Return the JSON schema for MimeType."""
         return {
             "type": "string",
             "format": "mime-type",

--- a/tests/devops/test_docker.py
+++ b/tests/devops/test_docker.py
@@ -1,3 +1,5 @@
+"""Tests for Docker image reference types."""
+
 from __future__ import annotations
 
 import pytest
@@ -13,75 +15,84 @@ class ImageModel(BaseModel):
     ref: DockerImageRef
 
 
-class TestDockerImageRefValid:
-    def test_simple_image(self) -> None:
-        ref = DockerImageRef("nginx")
-        assert ref.registry is None
-        assert ref.repository == "nginx"
-        assert ref.tag is None
-        assert ref.digest is None
-
-    def test_image_with_tag(self) -> None:
-        ref = DockerImageRef("nginx:latest")
-        assert ref.registry is None
-        assert ref.repository == "nginx"
-        assert ref.tag == "latest"
-        assert ref.digest is None
-
-    def test_library_image_with_tag(self) -> None:
-        ref = DockerImageRef("library/nginx:1.21")
-        assert ref.registry is None
-        assert ref.repository == "library/nginx"
-        assert ref.tag == "1.21"
-
-    def test_registry_image(self) -> None:
-        ref = DockerImageRef("ghcr.io/owner/repo:v1.0")
-        assert ref.registry == "ghcr.io"
-        assert ref.repository == "owner/repo"
-        assert ref.tag == "v1.0"
-        assert ref.digest is None
-
-    def test_registry_with_port(self) -> None:
-        ref = DockerImageRef("registry.example.com:5000/my-app:latest")
-        assert ref.registry == "registry.example.com:5000"
-        assert ref.repository == "my-app"
-        assert ref.tag == "latest"
-
-    def test_digest_only(self) -> None:
-        ref = DockerImageRef("my-app@sha256:" + _DIGEST)
-        assert ref.registry is None
-        assert ref.repository == "my-app"
-        assert ref.tag is None
-        assert ref.digest == "sha256:" + _DIGEST
-
-    def test_tag_and_digest(self) -> None:
-        ref = DockerImageRef("nginx:latest@sha256:" + _DIGEST)
-        assert ref.tag == "latest"
-        assert ref.digest == "sha256:" + _DIGEST
-
-    def test_pydantic_model(self) -> None:
-        m = ImageModel(ref="nginx:latest")
-        assert isinstance(m.ref, DockerImageRef)
-        assert m.ref.tag == "latest"
+def test_valid_docker_image_ref_simple() -> None:
+    ref = DockerImageRef("nginx")
+    assert ref.registry is None
+    assert ref.repository == "nginx"
+    assert ref.tag is None
+    assert ref.digest is None
 
 
-class TestDockerImageRefInvalid:
-    def test_empty_string(self) -> None:
-        with pytest.raises(PydanticCustomError):
-            DockerImageRef("")
+def test_valid_docker_image_ref_with_tag() -> None:
+    ref = DockerImageRef("nginx:latest")
+    assert ref.registry is None
+    assert ref.repository == "nginx"
+    assert ref.tag == "latest"
+    assert ref.digest is None
 
-    def test_uppercase_repo(self) -> None:
-        with pytest.raises(PydanticCustomError):
-            DockerImageRef("UPPERCASE:latest")
 
-    def test_no_repo_tag_only(self) -> None:
-        with pytest.raises(PydanticCustomError):
-            DockerImageRef(":tag")
+def test_valid_docker_image_ref_library_with_tag() -> None:
+    ref = DockerImageRef("library/nginx:1.21")
+    assert ref.registry is None
+    assert ref.repository == "library/nginx"
+    assert ref.tag == "1.21"
 
-    def test_no_repo_digest_only(self) -> None:
-        with pytest.raises(PydanticCustomError):
-            DockerImageRef("@sha256:abc")
 
-    def test_pydantic_model_invalid(self) -> None:
-        with pytest.raises(ValidationError):
-            ImageModel(ref="")
+def test_valid_docker_image_ref_registry() -> None:
+    ref = DockerImageRef("ghcr.io/owner/repo:v1.0")
+    assert ref.registry == "ghcr.io"
+    assert ref.repository == "owner/repo"
+    assert ref.tag == "v1.0"
+    assert ref.digest is None
+
+
+def test_valid_docker_image_ref_registry_with_port() -> None:
+    ref = DockerImageRef("registry.example.com:5000/my-app:latest")
+    assert ref.registry == "registry.example.com:5000"
+    assert ref.repository == "my-app"
+    assert ref.tag == "latest"
+
+
+def test_valid_docker_image_ref_digest_only() -> None:
+    ref = DockerImageRef("my-app@sha256:" + _DIGEST)
+    assert ref.registry is None
+    assert ref.repository == "my-app"
+    assert ref.tag is None
+    assert ref.digest == "sha256:" + _DIGEST
+
+
+def test_valid_docker_image_ref_tag_and_digest() -> None:
+    ref = DockerImageRef("nginx:latest@sha256:" + _DIGEST)
+    assert ref.tag == "latest"
+    assert ref.digest == "sha256:" + _DIGEST
+
+
+def test_docker_image_ref_pydantic_model() -> None:
+    m = ImageModel(ref="nginx:latest")
+    assert isinstance(m.ref, DockerImageRef)
+    assert m.ref.tag == "latest"
+
+
+def test_invalid_docker_image_ref_empty() -> None:
+    with pytest.raises(PydanticCustomError):
+        DockerImageRef("")
+
+
+def test_invalid_docker_image_ref_uppercase_repo() -> None:
+    with pytest.raises(PydanticCustomError):
+        DockerImageRef("UPPERCASE:latest")
+
+
+def test_invalid_docker_image_ref_no_repo_tag_only() -> None:
+    with pytest.raises(PydanticCustomError):
+        DockerImageRef(":tag")
+
+
+def test_invalid_docker_image_ref_no_repo_digest_only() -> None:
+    with pytest.raises(PydanticCustomError):
+        DockerImageRef("@sha256:abc")
+
+
+def test_invalid_docker_image_ref_pydantic_model() -> None:
+    with pytest.raises(ValidationError):
+        ImageModel(ref="")

--- a/tests/devops/test_helm.py
+++ b/tests/devops/test_helm.py
@@ -1,3 +1,5 @@
+"""Tests for Helm chart reference types."""
+
 from __future__ import annotations
 
 import pytest
@@ -10,30 +12,16 @@ class HelmModel(BaseModel):
     name: HelmChartName
 
 
-class TestHelmChartNameValid:
-    @pytest.mark.parametrize("value", ["nginx", "cert-manager", "0-start-with-num"])
-    def test_valid_names(self, value: str) -> None:
-        m = HelmModel(name=value)
-        assert m.name == value
+@pytest.mark.parametrize("value", ["nginx", "cert-manager", "0-start-with-num"])
+def test_valid_helm_chart_name(value: str) -> None:
+    m = HelmModel(name=value)
+    assert m.name == value
 
 
-class TestHelmChartNameInvalid:
-    def test_empty(self) -> None:
-        with pytest.raises(ValidationError):
-            HelmModel(name="")
-
-    def test_starts_with_dash(self) -> None:
-        with pytest.raises(ValidationError):
-            HelmModel(name="-starts")
-
-    def test_uppercase(self) -> None:
-        with pytest.raises(ValidationError):
-            HelmModel(name="UPPER")
-
-    def test_has_spaces(self) -> None:
-        with pytest.raises(ValidationError):
-            HelmModel(name="has spaces")
-
-    def test_has_dots(self) -> None:
-        with pytest.raises(ValidationError):
-            HelmModel(name="has.dots")
+@pytest.mark.parametrize(
+    "value",
+    ["", "-starts", "UPPER", "has spaces", "has.dots"],
+)
+def test_invalid_helm_chart_name(value: str) -> None:
+    with pytest.raises(ValidationError):
+        HelmModel(name=value)

--- a/tests/devops/test_k8s.py
+++ b/tests/devops/test_k8s.py
@@ -1,3 +1,5 @@
+"""Tests for Kubernetes resource types."""
+
 from __future__ import annotations
 
 import pytest
@@ -28,153 +30,72 @@ class LabelValueModel(BaseModel):
     val: K8sLabelValue
 
 
-class TestK8sNamespaceNameValid:
-    def test_default(self) -> None:
-        m = NsModel(ns="default")
-        assert m.ns == "default"
-
-    def test_kube_system(self) -> None:
-        m = NsModel(ns="kube-system")
-        assert m.ns == "kube-system"
-
-    def test_single_char(self) -> None:
-        m = NsModel(ns="a")
-        assert m.ns == "a"
-
-    def test_max_length(self) -> None:
-        m = NsModel(ns="a" * 63)
-        assert len(m.ns) == 63
+@pytest.mark.parametrize("value", ["default", "kube-system", "a", "a" * 63])
+def test_valid_k8s_namespace_name(value: str) -> None:
+    m = NsModel(ns=value)
+    assert m.ns == value
 
 
-class TestK8sNamespaceNameInvalid:
-    def test_empty(self) -> None:
-        with pytest.raises(ValidationError):
-            NsModel(ns="")
-
-    def test_starts_with_dash(self) -> None:
-        with pytest.raises(ValidationError):
-            NsModel(ns="-starts")
-
-    def test_ends_with_dash(self) -> None:
-        with pytest.raises(ValidationError):
-            NsModel(ns="ends-")
-
-    def test_uppercase(self) -> None:
-        with pytest.raises(ValidationError):
-            NsModel(ns="UPPER")
-
-    def test_too_long(self) -> None:
-        with pytest.raises(ValidationError):
-            NsModel(ns="a" * 64)
+@pytest.mark.parametrize("value", ["", "-starts", "ends-", "UPPER", "a" * 64])
+def test_invalid_k8s_namespace_name(value: str) -> None:
+    with pytest.raises(ValidationError):
+        NsModel(ns=value)
 
 
-class TestK8sResourceNameValid:
-    def test_deployment(self) -> None:
-        m = ResModel(name="my-deployment")
-        assert m.name == "my-deployment"
-
-    def test_single_char(self) -> None:
-        m = ResModel(name="a")
-        assert m.name == "a"
-
-    def test_subdomain(self) -> None:
-        m = ResModel(name="sub.domain.name")
-        assert m.name == "sub.domain.name"
+@pytest.mark.parametrize("value", ["my-deployment", "a", "sub.domain.name"])
+def test_valid_k8s_resource_name(value: str) -> None:
+    m = ResModel(name=value)
+    assert m.name == value
 
 
-class TestK8sResourceNameInvalid:
-    def test_empty(self) -> None:
-        with pytest.raises(ValidationError):
-            ResModel(name="")
-
-    def test_starts_with_dash(self) -> None:
-        with pytest.raises(ValidationError):
-            ResModel(name="-starts")
-
-    def test_too_long(self) -> None:
-        with pytest.raises(ValidationError):
-            ResModel(name="a" * 254)
-
-    def test_consecutive_dots(self) -> None:
-        with pytest.raises(ValidationError):
-            ResModel(name="has..dots")
+@pytest.mark.parametrize("value", ["", "-starts", "a" * 254, "has..dots"])
+def test_invalid_k8s_resource_name(value: str) -> None:
+    with pytest.raises(ValidationError):
+        ResModel(name=value)
 
 
-class TestK8sLabelKeyValid:
-    def test_simple_name(self) -> None:
-        k = K8sLabelKey("app")
-        assert k.prefix is None
-        assert k.name == "app"
-
-    def test_version(self) -> None:
-        k = K8sLabelKey("version")
-        assert k.prefix is None
-        assert k.name == "version"
-
-    def test_prefixed_key(self) -> None:
-        k = K8sLabelKey("app.kubernetes.io/name")
-        assert k.prefix == "app.kubernetes.io"
-        assert k.name == "name"
-
-    def test_my_label(self) -> None:
-        k = K8sLabelKey("my-label")
-        assert k.prefix is None
-        assert k.name == "my-label"
-
-    def test_pydantic_model(self) -> None:
-        m = LabelKeyModel(key="version")
-        assert isinstance(m.key, K8sLabelKey)
+def test_valid_k8s_label_key_simple_name() -> None:
+    k = K8sLabelKey("app")
+    assert k.prefix is None
+    assert k.name == "app"
 
 
-class TestK8sLabelKeyInvalid:
-    def test_empty(self) -> None:
-        with pytest.raises(PydanticCustomError):
-            K8sLabelKey("")
-
-    def test_empty_prefix(self) -> None:
-        with pytest.raises(PydanticCustomError):
-            K8sLabelKey("/name")
-
-    def test_name_too_long(self) -> None:
-        with pytest.raises(PydanticCustomError):
-            K8sLabelKey("a" * 64)
+def test_valid_k8s_label_key_version() -> None:
+    k = K8sLabelKey("version")
+    assert k.prefix is None
+    assert k.name == "version"
 
 
-class TestK8sLabelValueValid:
-    def test_version(self) -> None:
-        m = LabelValueModel(val="v1.0")
-        assert m.val == "v1.0"
-
-    def test_production(self) -> None:
-        m = LabelValueModel(val="production")
-        assert m.val == "production"
-
-    def test_empty(self) -> None:
-        m = LabelValueModel(val="")
-        assert m.val == ""
-
-    def test_single_char(self) -> None:
-        m = LabelValueModel(val="a")
-        assert m.val == "a"
-
-    def test_max_length(self) -> None:
-        m = LabelValueModel(val="a" * 63)
-        assert len(m.val) == 63
+def test_valid_k8s_label_key_prefixed() -> None:
+    k = K8sLabelKey("app.kubernetes.io/name")
+    assert k.prefix == "app.kubernetes.io"
+    assert k.name == "name"
 
 
-class TestK8sLabelValueInvalid:
-    def test_starts_with_dash(self) -> None:
-        with pytest.raises(ValidationError):
-            LabelValueModel(val="-starts")
+def test_valid_k8s_label_key_with_dash() -> None:
+    k = K8sLabelKey("my-label")
+    assert k.prefix is None
+    assert k.name == "my-label"
 
-    def test_ends_with_dash(self) -> None:
-        with pytest.raises(ValidationError):
-            LabelValueModel(val="ends-")
 
-    def test_too_long(self) -> None:
-        with pytest.raises(ValidationError):
-            LabelValueModel(val="a" * 64)
+def test_k8s_label_key_pydantic_model() -> None:
+    m = LabelKeyModel(key="version")
+    assert isinstance(m.key, K8sLabelKey)
 
-    def test_has_spaces(self) -> None:
-        with pytest.raises(ValidationError):
-            LabelValueModel(val="has spaces")
+
+@pytest.mark.parametrize("value", ["", "/name", "a" * 64])
+def test_invalid_k8s_label_key(value: str) -> None:
+    with pytest.raises(PydanticCustomError):
+        K8sLabelKey(value)
+
+
+@pytest.mark.parametrize("value", ["v1.0", "production", "", "a", "a" * 63])
+def test_valid_k8s_label_value(value: str) -> None:
+    m = LabelValueModel(val=value)
+    assert m.val == value
+
+
+@pytest.mark.parametrize("value", ["-starts", "ends-", "a" * 64, "has spaces"])
+def test_invalid_k8s_label_value(value: str) -> None:
+    with pytest.raises(ValidationError):
+        LabelValueModel(val=value)

--- a/tests/devops/test_terraform.py
+++ b/tests/devops/test_terraform.py
@@ -1,3 +1,5 @@
+"""Tests for Terraform resource identifier types."""
+
 from __future__ import annotations
 
 import pytest
@@ -11,44 +13,30 @@ class TfModel(BaseModel):
     addr: TerraformResourceAddress
 
 
-class TestTerraformValid:
-    def test_aws_instance(self) -> None:
-        addr = TerraformResourceAddress("aws_instance.web")
-        assert addr.resource_type == "aws_instance"
-        assert addr.resource_name == "web"
-
-    def test_google_compute(self) -> None:
-        addr = TerraformResourceAddress("google_compute_instance.default")
-        assert addr.resource_type == "google_compute_instance"
-        assert addr.resource_name == "default"
-
-    def test_null_resource(self) -> None:
-        addr = TerraformResourceAddress("null_resource.this")
-        assert addr.resource_type == "null_resource"
-        assert addr.resource_name == "this"
-
-    def test_pydantic_model(self) -> None:
-        m = TfModel(addr="aws_instance.web")
-        assert isinstance(m.addr, TerraformResourceAddress)
+def test_valid_terraform_resource_address_aws_instance() -> None:
+    addr = TerraformResourceAddress("aws_instance.web")
+    assert addr.resource_type == "aws_instance"
+    assert addr.resource_name == "web"
 
 
-class TestTerraformInvalid:
-    def test_empty(self) -> None:
-        with pytest.raises(PydanticCustomError):
-            TerraformResourceAddress("")
+def test_valid_terraform_resource_address_google_compute() -> None:
+    addr = TerraformResourceAddress("google_compute_instance.default")
+    assert addr.resource_type == "google_compute_instance"
+    assert addr.resource_name == "default"
 
-    def test_no_dot(self) -> None:
-        with pytest.raises(PydanticCustomError):
-            TerraformResourceAddress("no-dot")
 
-    def test_starts_with_dot(self) -> None:
-        with pytest.raises(PydanticCustomError):
-            TerraformResourceAddress(".starts-with-dot")
+def test_valid_terraform_resource_address_null_resource() -> None:
+    addr = TerraformResourceAddress("null_resource.this")
+    assert addr.resource_type == "null_resource"
+    assert addr.resource_name == "this"
 
-    def test_starts_with_digit(self) -> None:
-        with pytest.raises(PydanticCustomError):
-            TerraformResourceAddress("1invalid.name")
 
-    def test_empty_name(self) -> None:
-        with pytest.raises(PydanticCustomError):
-            TerraformResourceAddress("type.")
+def test_terraform_resource_address_pydantic_model() -> None:
+    m = TfModel(addr="aws_instance.web")
+    assert isinstance(m.addr, TerraformResourceAddress)
+
+
+@pytest.mark.parametrize("value", ["", "no-dot", ".starts-with-dot", "1invalid.name", "type."])
+def test_invalid_terraform_resource_address(value: str) -> None:
+    with pytest.raises(PydanticCustomError):
+        TerraformResourceAddress(value)


### PR DESCRIPTION
## Summary

- Standardize type patterns across all modules (devops/, web/, data/) to match the cloud/ exemplar conventions documented in ARCHITECTURE.md
- Add "Protect main" branch ruleset via GitHub API (required status checks, no force push, no deletion, linear history, admin bypass)
- Add CODEOWNERS (`@oborchers` for all files)
- Add PR template with summary + checklist
- Add YAML-form issue templates for bug reports and feature requests
- Add Dependabot auto-merge workflow for patch/minor updates
- Add labels to Dependabot config for better PR triage

## Test plan

- [ ] `make check` passes (CI will verify)
- [ ] Verify ruleset: `gh api repos/oborchers/pydantypes/rulesets --jq '.[].name'`
- [ ] Verify issue templates render correctly on GitHub
- [ ] Verify PR template renders on new PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)