### PR TITLE
Add BearerToken type and schwifty reference

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -430,20 +430,32 @@ pydantypes fills gaps — it never reimplements types already provided by Pydant
 - **Encoding**: `Base64Bytes`, `Base64Str`, `Base64UrlBytes`, `Base64UrlStr`
 - **Other**: `ByteSize`, `ImportString`, `Json`, `PaymentCardNumber` (deprecated)
 
-### pydantic-extra-types (DO NOT duplicate)
+### Third-party Pydantic-native libraries (DO NOT duplicate)
 
-- `Color` (hex, RGB, HSL, named colors)
-- `Coordinate` (latitude/longitude)
-- `CountryAlpha2`, `CountryAlpha3`, `CountryNumeric`, `CountryShortName`
-- `Currency` (ISO 4217)
+- [schwifty](https://github.com/mdomke/schwifty) — `IBAN`, `BIC` (banking identifiers with native `__get_pydantic_core_schema__` support)
+
+### pydantic-extra-types v2.11.0 (DO NOT duplicate)
+
+- `Color`, `RGBA` (hex, RGB, HSL, named colors)
+- `Coordinate`, `Latitude`, `Longitude`
+- `CountryAlpha2`, `CountryAlpha3`, `CountryNumericCode`, `CountryShortName`
+- `CronStr` (cron expressions via `cron-converter`)
+- `DomainStr` (basic domain name validation)
+- `epoch.Number`, `epoch.Integer` (datetime from unix timestamp)
+- `ISO4217`, `Currency` (currency codes)
 - `ISBN`
-- `LanguageAlpha2`, `LanguageName`
+- `ISO_15924` (script codes)
+- `LanguageAlpha2`, `LanguageName`, `ISO639_3`, `ISO639_5`
 - `MacAddress`
-- `PaymentCardNumber`
+- `MimeType` (IANA whitelist lookup — distinct from pydantypes' RFC 6838 format validator)
+- `MongoObjectId`
+- `PaymentCardNumber`, `PaymentCardBrand`
 - `PhoneNumber`
 - `ABARoutingNumber`
-- `ScriptCode`
-- `SemanticVersion`
-- `TimezoneName`, `TimezoneNameLoose`
+- `S3Path` (basic S3 path — distinct from pydantypes' `S3Uri` with full property extraction)
+- `SemanticVersion`, `ManifestVersion`
+- `TimeZoneName`
 - `ULID`
-- Pendulum datetime types
+- `UUID6`, `UUID7`, `UUID8`
+- Path types: `ExistingPath`, `ResolvedFilePath`, `ResolvedDirectoryPath`, `ResolvedNewPath`
+- Pendulum datetime types (`DateTime`, `Date`, `Time`, `Duration`)

--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ result.sentiment.description  # "Expresses approval or satisfaction"
 
 pydantypes is designed as a complement to [pydantic-extra-types](https://github.com/pydantic/pydantic-extra-types). While pydantic-extra-types covers general-purpose types (colors, phone numbers, payment cards), pydantypes focuses on infrastructure and engineering identifiers.
 
+For **IBAN and BIC** (banking identifiers), use [schwifty](https://github.com/mdomke/schwifty) which provides native Pydantic v2 support with `__get_pydantic_core_schema__`.
+
 - Requires **Pydantic v2.5.2+**
 - Supports **Python 3.10–3.13**
 

--- a/src/pydantypes/web/__init__.py
+++ b/src/pydantypes/web/__init__.py
@@ -1,9 +1,11 @@
+from pydantypes.web.auth import BearerToken
 from pydantypes.web.hash import Md5Hex, Sha1Hex, Sha256Hex
 from pydantypes.web.jwt import Jwt
 from pydantypes.web.mime import MimeType
 from pydantypes.web.network import Fqdn, PortRange
 
 __all__ = [
+    "BearerToken",
     "Fqdn",
     "Jwt",
     "Md5Hex",

--- a/src/pydantypes/web/auth.py
+++ b/src/pydantypes/web/auth.py
@@ -1,0 +1,60 @@
+"""Validated types for HTTP authentication headers."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, ClassVar
+
+from pydantic import GetCoreSchemaHandler, GetJsonSchemaHandler
+from pydantic.json_schema import JsonSchemaValue
+from pydantic_core import CoreSchema, PydanticCustomError
+
+from pydantypes._internal import _str_type_core_schema
+
+
+# Source: https://datatracker.ietf.org/doc/html/rfc6750
+class BearerToken(str):
+    """A Bearer token string like 'Bearer <token>' with the extracted token value."""
+
+    _pattern: ClassVar[re.Pattern[str]] = re.compile(r"^Bearer ([a-zA-Z0-9._~+/]+=*)$")
+
+    token: str
+
+    def __new__(cls, value: str) -> BearerToken:
+        """Create and validate a new BearerToken instance."""
+        m = cls._pattern.match(value)
+        if not m:
+            raise PydanticCustomError(
+                "bearer_token",
+                "Invalid Bearer token: {value}",
+                {"value": value},
+            )
+        instance = str.__new__(cls, value)
+        instance.token = m.group(1)
+        return instance
+
+    @classmethod
+    def _validate(cls, value: str) -> BearerToken:
+        """Validate a string as a Bearer token."""
+        return cls(value)
+
+    @classmethod
+    def __get_pydantic_core_schema__(
+        cls, source_type: Any, handler: GetCoreSchemaHandler
+    ) -> CoreSchema:
+        """Return the Pydantic core schema for BearerToken."""
+        return _str_type_core_schema(cls, source_type, handler)
+
+    @classmethod
+    def __get_pydantic_json_schema__(
+        cls, _core_schema: CoreSchema, handler: GetJsonSchemaHandler
+    ) -> JsonSchemaValue:
+        """Return the JSON schema for BearerToken."""
+        return {
+            "type": "string",
+            "format": "bearer-token",
+            "pattern": cls._pattern.pattern,
+            "description": "An HTTP Bearer token (RFC 6750)",
+            "examples": ["Bearer eyJhbGciOiJIUzI1NiIs..."],
+            "title": "BearerToken",
+        }

--- a/tests/web/test_auth.py
+++ b/tests/web/test_auth.py
@@ -1,0 +1,77 @@
+"""Tests for HTTP authentication types."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import BaseModel, ValidationError
+
+from pydantypes.web.auth import BearerToken
+
+
+class BearerTokenModel(BaseModel):
+    auth: BearerToken
+
+
+@pytest.mark.parametrize(
+    ("value", "expected_token"),
+    [
+        ("Bearer abc123", "abc123"),
+        (
+            "Bearer eyJhbGciOiJIUzI1NiIs.eyJzdWIiOiIxMjM0NTY3ODkwIn0.sig",
+            "eyJhbGciOiJIUzI1NiIs.eyJzdWIiOiIxMjM0NTY3ODkwIn0.sig",
+        ),
+        ("Bearer token+with/special~chars._ok", "token+with/special~chars._ok"),
+        ("Bearer abc123==", "abc123=="),
+        ("Bearer a", "a"),
+        (
+            "Bearer ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789",
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789",
+        ),
+    ],
+)
+def test_valid_bearer_token(value: str, expected_token: str) -> None:
+    model = BearerTokenModel(auth=value)
+    assert str(model.auth) == value
+    assert model.auth.token == expected_token
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "",
+        "bearer abc123",
+        "BEARER abc123",
+        "Bearer ",
+        "Bearer",
+        "Bearer  abc123",
+        "Basic dXNlcjpwYXNz",
+        "abc123",
+        "Bearer @invalid",
+        "Bearer has space",
+    ],
+)
+def test_invalid_bearer_token(value: str) -> None:
+    with pytest.raises(ValidationError):
+        BearerTokenModel(auth=value)
+
+
+def test_bearer_token_serialization() -> None:
+    model = BearerTokenModel(auth="Bearer mytoken123")
+    assert model.model_dump() == {"auth": "Bearer mytoken123"}
+    json_str = model.model_dump_json()
+    restored = BearerTokenModel.model_validate_json(json_str)
+    assert restored.auth == model.auth
+    assert restored.auth.token == "mytoken123"
+
+
+def test_bearer_token_existing_instance() -> None:
+    bt = BearerToken("Bearer mytoken123")
+    model = BearerTokenModel(auth=bt)
+    assert model.auth is bt
+
+
+def test_bearer_token_json_schema() -> None:
+    schema = BearerTokenModel.model_json_schema()
+    field_schema = schema["properties"]["auth"]
+    assert field_schema["type"] == "string"
+    assert field_schema["format"] == "bearer-token"


### PR DESCRIPTION
## Summary

- Add `BearerToken` (Pattern A) to `web/auth.py` — validates RFC 6750 Bearer token strings and extracts the token value via `.token` property
- Add [schwifty](https://github.com/mdomke/schwifty) reference to README compatibility section and ARCHITECTURE No-Overlap section for IBAN/BIC banking identifiers (native Pydantic v2 support)

## Test plan

- [ ] `make check` passes (lint + typecheck + 1043 tests)
- [ ] Valid Bearer tokens accepted with correct `.token` extraction
- [ ] Invalid tokens rejected (wrong scheme, empty token, bad chars, double space)
- [ ] Serialization round-trip works
- [ ] Existing instance identity preserved
- [ ] JSON schema includes `format: "bearer-token"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)